### PR TITLE
Add service definition for easier access

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -20,3 +20,17 @@ spec:
         ports:
         - name: http
           containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pprof-example-app-go
+  labels:
+    app.kubernetes.io/name: pprof-example-app-go
+spec:
+  selector:
+    app.kubernetes.io/name: pprof-example-app-go
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080


### PR DESCRIPTION
The manifest created a deployment but it seems like it might be easier to reach the profiles generated by the example app with a service definition. This PR adds a service so that it's possible to use `pprof-example-app-go:8080` as a target to scrape from.